### PR TITLE
Register models for the admin site.

### DIFF
--- a/helloworld/greet/admin.py
+++ b/helloworld/greet/admin.py
@@ -1,0 +1,8 @@
+# Copyright 2021 Pants project contributors.
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from django.contrib import admin
+
+from helloworld.greet.models import Greeting
+
+admin.site.register(Greeting)

--- a/helloworld/greet/models.py
+++ b/helloworld/greet/models.py
@@ -22,3 +22,6 @@ class Greeting(models.Model):
         if greetings:
             return greetings[0]
         return None
+
+    def __str__(self):
+        return self.slug

--- a/helloworld/person/admin.py
+++ b/helloworld/person/admin.py
@@ -1,0 +1,8 @@
+# Copyright 2021 Pants project contributors.
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from django.contrib import admin
+
+from helloworld.person.models import Person
+
+admin.site.register(Person)

--- a/helloworld/person/models.py
+++ b/helloworld/person/models.py
@@ -4,6 +4,10 @@
 from django.db import models
 
 
+# Note: This is distinct from the standard auth app's User model, for clarity.
 class Person(models.Model):
     slug = models.CharField(max_length=20, unique=True)
     full_name = models.CharField(max_length=50)
+
+    def __str__(self):
+        return self.slug

--- a/helloworld/translate/admin.py
+++ b/helloworld/translate/admin.py
@@ -1,0 +1,8 @@
+# Copyright 2021 Pants project contributors.
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from django.contrib import admin
+
+from helloworld.translate.models import Translation
+
+admin.site.register(Translation)

--- a/helloworld/translate/models.py
+++ b/helloworld/translate/models.py
@@ -6,14 +6,25 @@ from django.db import models
 from helloworld.greet.models import Greeting
 
 
+class TranslationManager(models.Manager):
+    def get_queryset(self):
+        qs = super().get_queryset()
+        return qs.select_related("greeting")
+
+
 class Translation(models.Model):
     class Meta:
         constraints = [
             models.UniqueConstraint(fields=["greeting", "lang"], name="greeting_lang")
         ]
 
+    objects = TranslationManager()
+
     # NB: This Translation model share a database with the Greeting model, so this
     #  relation is allowed by our database router.
     greeting = models.ForeignKey(Greeting, on_delete=models.CASCADE)
     lang = models.CharField(max_length=2)
     translation = models.CharField(max_length=20)
+
+    def __str__(self):
+        return f"{self.greeting} in {self.lang}"


### PR DESCRIPTION
Also:
  - Make sure models have a useful __str__.
  - Make sure the Translation model always
    joins to its Greeting, to avoid N+1 queries.