### PR TITLE
Ensure that migrate writes sqlite dbs into the cwd.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ __pycache__/
 
 # Local databases.
 *.sqlite3
+*.sqlite3-journal
 
 # MacOS attribute files
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -126,5 +126,5 @@ To run migrations, it's best to use the admin service's manage.py, as it has acc
 all apps:
 
 ```
-./pants helloworld/service/admin/manage.py -- migrate --database=users --database=greetings
+./pants run helloworld/service/admin/manage.py -- migrate --database=users --database=greetings
 ```

--- a/helloworld/settings_base.py
+++ b/helloworld/settings_base.py
@@ -10,9 +10,6 @@ from helloworld.util.per_app_db_router import PerAppDBRouter
 
 HELLOWORLD_MODE = os.environ.get("HELLOWORLD_MODE", "DEV")
 
-# Construct paths inside the project like this: os.path.join(BASE_DIR, ...)
-BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-
 SECRET_KEY = "DEV_SECURITY_KEY"
 
 DEBUG = True
@@ -55,7 +52,7 @@ def set_up_database(db_name: str):
     # TODO: Consult HELLOWORLD_MODE to distinguish dev/staging/prod dbs.
     DATABASES[db_name] = {
         "ENGINE": "django.db.backends.sqlite3",
-        "NAME": os.path.join(BASE_DIR, f"{db_name}.sqlite3"),
+        "NAME": f"{db_name}.sqlite3",
     }
 
 


### PR DESCRIPTION
Previously it would write them into the sandbox if created by
./pants run.

Also gitignores the sqlite journal file, so that pants will
ignore it too, preventing spurious file watcher events as
the migrations are applied.