### PR TITLE
Upgrade to Pants 2.10.

### DIFF
--- a/.github/workflows/pants.yaml
+++ b/.github/workflows/pants.yaml
@@ -40,9 +40,9 @@ jobs:
         ./pants --version
     - name: Check BUILD files
       run: ./pants tailor --check update-build-files --check
-    - name: Lint and typecheck
+    - name: Lint
       run: | 
-        ./pants lint check ::
+        ./pants lint ::
     - name: Test
       run: |
         ./pants test ::

--- a/BUILD
+++ b/BUILD
@@ -1,4 +1,4 @@
 # Copyright 2021 Pants project contributors.
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-python_requirements()
+python_requirements(name="requirements")

--- a/pants
+++ b/pants
@@ -34,9 +34,9 @@ fi
 
 PANTS_BOOTSTRAP="${PANTS_SETUP_CACHE}/bootstrap-$(uname -s)-$(uname -m)"
 
-_PEX_VERSION=2.1.42
+_PEX_VERSION=2.1.62
 _PEX_URL="https://github.com/pantsbuild/pex/releases/download/v${_PEX_VERSION}/pex"
-_PEX_EXPECTED_SHA256="69d6b1b1009b00dd14a3a9f19b72cff818a713ca44b3186c9b12074b2a31e51f"
+_PEX_EXPECTED_SHA256="56668b1ca147bd63141e586ffee97c7cc51ce8e6eac6c9b7a4bf1215b94396e5"
 
 VIRTUALENV_VERSION=20.4.7
 VIRTUALENV_REQUIREMENTS=$(
@@ -87,13 +87,18 @@ function get_exe_path_or_die {
   fi
 }
 
-function get_pants_config_value {
+function get_pants_config_string_value {
   local config_key="$1"
   local optional_space="[[:space:]]*"
   local prefix="^${config_key}${optional_space}=${optional_space}"
   local raw_value
-  raw_value="$(sed -ne "/${prefix}/ s#${prefix}##p" "${PANTS_TOML}")"
-  echo "${raw_value}"  | tr -d \"\' && return 0
+  raw_value="$(sed -ne "/${prefix}/ s|${prefix}||p" "${PANTS_TOML}")"
+  local optional_suffix="${optional_space}(#.*)?$"
+  echo "${raw_value}" \
+    | sed -E \
+      -e "s|^'([^']*)'${optional_suffix}|\1|" \
+      -e 's|^"([^"]*)"'"${optional_suffix}"'$|\1|' \
+    && return 0
   return 0
 }
 
@@ -125,7 +130,7 @@ function determine_pants_version {
     return
   fi
 
-  pants_version="$(get_pants_config_value 'pants_version')"
+  pants_version="$(get_pants_config_string_value 'pants_version')"
   if [[ -z "${pants_version}" ]]; then
     die "Please explicitly specify the \`pants_version\` in your \`pants.toml\` under the \`[GLOBAL]\` scope.
 See https://pypi.org/project/pantsbuild.pants/#history for all released versions
@@ -191,8 +196,8 @@ function determine_default_python_exe {
     if [[ -z "${interpreter_path}" ]]; then
       continue
     fi
-    # Check if the Python version is installed via Pyenv but not activated.
-    if [[ "$("${interpreter_path}" --version 2>&1 > /dev/null)" == "pyenv: python${version}"* ]]; then
+    # Check if a version is shimmed by pyenv or asdf but not configured.
+    if ! "${interpreter_path}" --version >/dev/null 2>&1; then
       continue
     fi
     if [[ -n "$(check_python_exe_compatible_version "${interpreter_path}")" ]]; then
@@ -249,7 +254,12 @@ function bootstrap_pex {
       local staging_dir
       staging_dir=$(tempdir "${PANTS_BOOTSTRAP}")
       cd "${staging_dir}"
-      curl -LO "${_PEX_URL}"
+      curl --proto "=https" \
+           --tlsv1.2 \
+           --silent \
+           --location \
+           --remote-name \
+           "${_PEX_URL}"
       fingerprint="$(compute_sha256 "${python}" "pex")"
       if [[ "${_PEX_EXPECTED_SHA256}" != "${fingerprint}" ]]; then
         die "SHA256 of ${_PEX_URL} is not as expected. Aborting."
@@ -307,7 +317,12 @@ function get_version_for_sha {
 
   # Retrieve the Pants version associated with this commit.
   local pants_version
-  pants_version="$(curl --fail -sL "https://raw.githubusercontent.com/pantsbuild/pants/${sha}/src/python/pants/VERSION")"
+  pants_version="$(curl --proto "=https" \
+                        --tlsv1.2 \
+                        --fail \
+                        --silent \
+                        --location \
+                        "https://raw.githubusercontent.com/pantsbuild/pants/${sha}/src/python/pants/VERSION")"
 
   # Construct the version as the release version from src/python/pants/VERSION, plus the string `+gitXXXXXXXX`,
   # where the XXXXXXXX is the first 8 characters of the SHA.
@@ -342,9 +357,11 @@ function bootstrap_pants {
       (
         scrub_PEX_env_vars
         # shellcheck disable=SC2086
-        "${python}" "${virtualenv_path}" --no-download "${staging_dir}/install" && \
-        "${staging_dir}/install/bin/pip" install -U pip && \
-        "${staging_dir}/install/bin/pip" install ${maybe_find_links} --progress-bar off "${pants_requirement}"
+        "${python}" "${virtualenv_path}" --quiet --no-download "${staging_dir}/install" && \
+        # Grab the latest pip, but don't advance setuptools past 58 which drops support for the
+        # `setup` kwarg `use_2to3` which Pants 1.x sdist dependencies (pystache) use.
+        "${staging_dir}/install/bin/pip" install --quiet -U pip "setuptools<58" && \
+        "${staging_dir}/install/bin/pip" install ${maybe_find_links} --quiet --progress-bar off "${pants_requirement}"
       ) && \
       ln -s "${staging_dir}/install" "${staging_dir}/${target_folder_name}" && \
       mv "${staging_dir}/${target_folder_name}" "${bootstrapped}" && \

--- a/pants.ci.toml
+++ b/pants.ci.toml
@@ -12,7 +12,7 @@ colors = true
 # the number of cores/threads.
 process_execution_local_parallelism = 2
 
-[python-setup]
+[python]
 # Limit the maximum number of concurrent jobs used to resolve third
 # party dependencies. The total level of parallelism will be
 # `process_execution_local_parallelism x resolver_jobs`.

--- a/pants.toml
+++ b/pants.toml
@@ -2,7 +2,8 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 [GLOBAL]
-pants_version = "2.8.0"
+pants_version = "2.10.0"
+use_deprecated_python_macros = false
 
 backend_packages.add = [
   'pants.backend.python',
@@ -28,11 +29,15 @@ root_patterns = ["/"]
 interpreter_constraints = [">=3.7"]
 # Use a lockfile. See https://www.pantsbuild.org/docs/python-third-party-dependencies.
 requirement_constraints = "constraints.txt"
+
+[python-bootstrap]
 # We search for interpreters on both on the $PATH and in the `$(pyenv root)/versions` folder.
-#  If you're using macOS, you may want to leave off the <PATH> entry to avoid using the
-#  problematic system Pythons. See
-#  https://www.pantsbuild.org/docs/python-interpreter-compatibility#changing-the-interpreter-search-path.
-interpreter_search_paths = ["<PATH>", "<PYENV>"]
+# Note the gotcha that the order of entries does not matter in this option, as Pants will consider
+# all interpreters it finds and select a compatible one.
+# So, if you're using macOS, you may want to leave off the <PATH> entry to avoid using the
+# problematic system Pythons. See
+# https://www.pantsbuild.org/docs/python-interpreter-compatibility#changing-the-interpreter-search-path.
+search_path = ["<PATH>", "<PYENV>"]
 
 [python-infer]
 # Infer dependencies from strings that look like module/class names, such as are often


### PR DESCRIPTION
Removes the typechecking from CI until we can get that working.

Also updates to the latest `pants` script.