### PR TITLE
Add explicit deps from manage.py to settings.py in each app.

### DIFF
--- a/helloworld/service/frontend/BUILD
+++ b/helloworld/service/frontend/BUILD
@@ -6,6 +6,9 @@ python_sources(
     dependencies=[
         "helloworld/ui",
     ],
+    overrides={
+        "manage.py": {"dependencies": ["helloworld/service/frontend/settings.py:lib"]}
+    },
 )
 
 pex_binary(

--- a/helloworld/service/user/BUILD
+++ b/helloworld/service/user/BUILD
@@ -6,6 +6,9 @@ python_sources(
     dependencies=[
         "helloworld/person",
     ],
+    overrides={
+        "manage.py": {"dependencies": ["helloworld/service/user/settings.py:lib"]}
+    },
 )
 
 pex_binary(

--- a/helloworld/service/welcome/BUILD
+++ b/helloworld/service/welcome/BUILD
@@ -7,6 +7,9 @@ python_sources(
         "helloworld/greet",
         "helloworld/translate",
     ],
+    overrides={
+        "manage.py": {"dependencies": ["helloworld/service/welcome/settings.py:lib"]}
+    },
 )
 
 pex_binary(


### PR DESCRIPTION
With this change, the example commands in the README work properly 
(e.g., `pants run helloworld/service/frontend/manage.py -- runserver`)

Also explicitly note the BUILDROOT, now that `./pants` is no more.