### PR TITLE
Demonstrate the right way to run manage.py from source.

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,8 +120,8 @@ pants run helloworld/service/admin/manage.py -- runserver
  Note that for `runserver`, each dev server will run on its own port, see DEV_PORTS in
 [`helloworld/util/discovery.py`](helloworld/util/discovery.py).
 
-Also, with `runserver` we turn off Django's autoreloader, since we rely on Pants's own
-file-watching instead, by setting `restartable=True` on the `pex_binary` targets for `manage.py`.
+Also, with `runserver` we [turn off](helloworld/util/service.py#L40) Django's autoreloader.
+Instead, we rely on Pants's own file-watching, by setting `restartable=True` on `manage.py`.
 Pants will correctly restart servers in situations where Django cannot, such as changes to 
 BUILD files, to `.proto` files, or to 3rdparty dependencies.
 

--- a/helloworld/greet/migrations/0001_initial.py
+++ b/helloworld/greet/migrations/0001_initial.py
@@ -7,7 +7,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = []

--- a/helloworld/greet/migrations/0002_data.py
+++ b/helloworld/greet/migrations/0002_data.py
@@ -29,7 +29,6 @@ def create_greetings(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("greet", "0001_initial"),
     ]

--- a/helloworld/person/migrations/0001_initial.py
+++ b/helloworld/person/migrations/0001_initial.py
@@ -7,7 +7,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = []

--- a/helloworld/person/migrations/0002_data.py
+++ b/helloworld/person/migrations/0002_data.py
@@ -21,7 +21,6 @@ def create_people_to_greet(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("person", "0001_initial"),
     ]

--- a/helloworld/service/admin/BUILD
+++ b/helloworld/service/admin/BUILD
@@ -8,6 +8,13 @@ python_sources(
         "helloworld/person",
         "helloworld/translate",
     ],
+    overrides={
+        "manage.py": {
+            "dependencies": ["helloworld/service/admin/settings.py:lib"],
+            "restartable": True,
+        },
+        "gunicorn.py": {"restartable": True},
+    },
 )
 
 pex_binary(
@@ -16,7 +23,6 @@ pex_binary(
     dependencies=[
         ":lib",
     ],
-    restartable=True,
 )
 
 pex_binary(
@@ -25,5 +31,4 @@ pex_binary(
     dependencies=[
         ":lib",
     ],
-    restartable=True,
 )

--- a/helloworld/service/frontend/BUILD
+++ b/helloworld/service/frontend/BUILD
@@ -7,7 +7,11 @@ python_sources(
         "helloworld/ui",
     ],
     overrides={
-        "manage.py": {"dependencies": ["helloworld/service/frontend/settings.py:lib"]}
+        "manage.py": {
+            "dependencies": ["helloworld/service/frontend/settings.py:lib"],
+            "restartable": True,
+        },
+        "gunicorn.py": {"restartable": True},
     },
 )
 
@@ -17,7 +21,6 @@ pex_binary(
     dependencies=[
         ":lib",
     ],
-    restartable=True,
 )
 
 pex_binary(
@@ -26,5 +29,4 @@ pex_binary(
     dependencies=[
         ":lib",
     ],
-    restartable=True,
 )

--- a/helloworld/service/user/BUILD
+++ b/helloworld/service/user/BUILD
@@ -7,7 +7,11 @@ python_sources(
         "helloworld/person",
     ],
     overrides={
-        "manage.py": {"dependencies": ["helloworld/service/user/settings.py:lib"]}
+        "manage.py": {
+            "dependencies": ["helloworld/service/user/settings.py:lib"],
+            "restartable": True,
+        },
+        "gunicorn.py": {"restartable": True},
     },
 )
 
@@ -17,7 +21,6 @@ pex_binary(
     dependencies=[
         ":lib",
     ],
-    restartable=True,
 )
 
 pex_binary(
@@ -26,5 +29,4 @@ pex_binary(
     dependencies=[
         ":lib",
     ],
-    restartable=True,
 )

--- a/helloworld/service/welcome/BUILD
+++ b/helloworld/service/welcome/BUILD
@@ -8,7 +8,11 @@ python_sources(
         "helloworld/translate",
     ],
     overrides={
-        "manage.py": {"dependencies": ["helloworld/service/welcome/settings.py:lib"]}
+        "manage.py": {
+            "dependencies": ["helloworld/service/welcome/settings.py:lib"],
+            "restartable": True,
+        },
+        "gunicorn.py": {"restartable": True},
     },
 )
 
@@ -18,7 +22,6 @@ pex_binary(
     dependencies=[
         ":lib",
     ],
-    restartable=True,
 )
 
 pex_binary(
@@ -27,5 +30,4 @@ pex_binary(
     dependencies=[
         ":lib",
     ],
-    restartable=True,
 )

--- a/helloworld/translate/migrations/0001_initial.py
+++ b/helloworld/translate/migrations/0001_initial.py
@@ -8,7 +8,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = [

--- a/helloworld/translate/migrations/0002_data.py
+++ b/helloworld/translate/migrations/0002_data.py
@@ -34,7 +34,6 @@ def create_greetings(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("translate", "0001_initial"),
         ("greet", "0002_data"),

--- a/pants.toml
+++ b/pants.toml
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 [GLOBAL]
-pants_version = "2.15.0"
+pants_version = "2.16.0rc0"
 
 backend_packages.add = [
   'pants.backend.python',


### PR DESCRIPTION
Updates to 2.16.0rc0, which supports setting "restartable" on a source file.

Then sets that on manage.py/gunicorn.py, instead of on their pex_binary targets. 
It is not useful to run the pex binary as a dev server, since every edit will rebuild the pex.

The upgrade forced a black upgrade which tweaked some lint.